### PR TITLE
feat: add minimal circuit selection for V3 inputs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,10 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.19.2
-      - uses: golangci/golangci-lint-action@v3
+          go-version: "1.25"
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.50.1
+          version: v2.8.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,19 +10,16 @@ jobs:
   test:
     strategy:
       matrix:
-        containers:
-        - 1.18.0-bullseye
-        - 1.19.2-bullseye
+        go-version:
+          - "1.21"
+          - "1.22"
+          - "1.23"
+          - "1.24"
+          - "1.25"
     runs-on: ubuntu-latest
-    container: golang:${{ matrix.containers }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          path: |
-            ~/.cache/go-build
-            /go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: ${{ matrix.go-version }}
       - run: go test -v -race -timeout=60s ./...

--- a/cmd/orderSignals/orderSignals.go
+++ b/cmd/orderSignals/orderSignals.go
@@ -49,7 +49,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	seenSignals := make(map[string]struct{})
 	var items []listItem

--- a/config_presets.go
+++ b/config_presets.go
@@ -1,0 +1,42 @@
+package circuits
+
+// Circuit configuration presets for minimal circuit selection.
+//
+// These presets correspond to circuit template instantiation parameters:
+//   - MTLevel        → issuerLevels (also used as idOwnershipLevels)
+//   - MTLevelClaim   → claimLevels
+//   - ValueArraySize → maxValueArraySize
+//   - MTLevelOnChain → onChainLevels
+//
+// Circuit mappings:
+//   - credentialAtomicQueryV3.circom                    → (40, 32, 64)
+//   - credentialAtomicQueryV3-16-16-64.circom           → (16, 16, 64)
+//   - credentialAtomicQueryV3OnChain.circom             → (40, 32, 64, 40, 64)
+//   - credentialAtomicQueryV3OnChain-16-16-64-16-32     → (16, 16, 64, 16, 32)
+//   - authV3.circom                                     → (40, 64)
+//   - authV3-8-32.circom                                → (8, 32)
+var (
+	// presetCfg40_32_64_64 is the large/default configuration for V3 circuits.
+	presetCfg40_32_64_64 = BaseConfig{
+		MTLevel:        40,
+		MTLevelClaim:   32,
+		ValueArraySize: 64,
+		MTLevelOnChain: 64,
+	}
+
+	// presetCfg16_16_64_32 is the small configuration for V3 circuits,
+	// suitable for proofs with shallower merkle trees.
+	presetCfg16_16_64_32 = BaseConfig{
+		MTLevel:        16,
+		MTLevelClaim:   16,
+		ValueArraySize: 64,
+		MTLevelOnChain: 32,
+	}
+
+	// presetCfg8_32 is the small configuration for AuthV3 circuits.
+	// Only MTLevel and MTLevelOnChain are used by auth circuits.
+	presetCfg8_32 = BaseConfig{
+		MTLevel:        8,
+		MTLevelOnChain: 32,
+	}
+)

--- a/credentialAtomicQueryMTPV2.go
+++ b/credentialAtomicQueryMTPV2.go
@@ -100,16 +100,16 @@ func (a AtomicQueryMTPV2Inputs) InputsMarshal() ([]byte, error) {
 		return nil, err
 	}
 
-	if a.Query.ValueProof != nil {
-		if err := a.Query.validate(); err != nil {
+	if a.ValueProof != nil {
+		if err := a.validate(); err != nil {
 			return nil, err
 		}
-		if err := a.Query.ValueProof.validate(); err != nil {
+		if err := a.ValueProof.validate(); err != nil {
 			return nil, err
 		}
 	}
 
-	valueProof := a.Query.ValueProof
+	valueProof := a.ValueProof
 	if valueProof == nil {
 		valueProof = &ValueProof{}
 		valueProof.Path = big.NewInt(0)

--- a/credentialAtomicQueryMTPV2OnChain.go
+++ b/credentialAtomicQueryMTPV2OnChain.go
@@ -160,16 +160,16 @@ func (a AtomicQueryMTPV2OnChainInputs) InputsMarshal() ([]byte, error) {
 		return nil, err
 	}
 
-	if a.Query.ValueProof != nil {
-		if err := a.Query.validate(); err != nil {
+	if a.ValueProof != nil {
+		if err := a.validate(); err != nil {
 			return nil, err
 		}
-		if err := a.Query.ValueProof.validate(); err != nil {
+		if err := a.ValueProof.validate(); err != nil {
 			return nil, err
 		}
 	}
 
-	valueProof := a.Query.ValueProof
+	valueProof := a.ValueProof
 	if valueProof == nil {
 		valueProof = &ValueProof{}
 		valueProof.Path = big.NewInt(0)

--- a/credentialAtomicQueryMTP_test.go
+++ b/credentialAtomicQueryMTP_test.go
@@ -22,7 +22,7 @@ func TestAtomicQuery_PrepareInputs(t *testing.T) {
 	challenge := new(big.Int).SetInt64(1)
 	ctx := context.Background()
 
-	userIdentity, uClaimsTree, uRevsTree, _, err, userAuthCoreClaim, userPrivateKey := it.Generate(ctx,
+	userIdentity, uClaimsTree, uRevsTree, _, userAuthCoreClaim, userPrivateKey, err := it.Generate(ctx,
 		userPrivKHex)
 	require.NoError(t, err)
 
@@ -52,7 +52,7 @@ func TestAtomicQuery_PrepareInputs(t *testing.T) {
 	challengeSignature := userPrivateKey.SignPoseidon(message)
 
 	// Issuer
-	issuerID, iClaimsTree, _, _, err, _, _ := it.Generate(ctx, issuerPrivKHex)
+	issuerID, iClaimsTree, _, _, _, _, err := it.Generate(ctx, issuerPrivKHex)
 	require.NoError(t, err)
 
 	// issue issuerClaim for user

--- a/credentialAtomicQuerySig_test.go
+++ b/credentialAtomicQuerySig_test.go
@@ -20,7 +20,7 @@ func TestAttrQuerySig_PrepareInputs(t *testing.T) {
 	challenge := new(big.Int).SetInt64(1)
 	ctx := context.Background()
 
-	userIdentity, uClaimsTree, _, _, err, userAuthCoreClaim, userPrivateKey := it.Generate(ctx,
+	userIdentity, uClaimsTree, _, _, userAuthCoreClaim, userPrivateKey, err := it.Generate(ctx,
 		userPrivKHex)
 	require.Nil(t, err)
 
@@ -49,7 +49,7 @@ func TestAttrQuerySig_PrepareInputs(t *testing.T) {
 	challengeSignature := userPrivateKey.SignPoseidon(message)
 
 	// Issuer
-	issuerIdentity, iClaimsTree, iRevTree, _, err, issuerAuthClaim, issuerKey := it.Generate(ctx,
+	issuerIdentity, iClaimsTree, iRevTree, _, issuerAuthClaim, issuerKey, err := it.Generate(ctx,
 		issuerPrivKHex)
 	require.Nil(t, err)
 

--- a/errors.go
+++ b/errors.go
@@ -32,4 +32,6 @@ const (
 	ErrorEmptyStateHash                  = "empty state hash"
 	ErrorUserProfileMismatch             = "profile DID derived from genesis does not match the credential subject or incorrect profile nonce"
 	ErrorNoCircuitsValidatorEntry        = "no circuits validator entry found for the given circuit ID"
+	ErrorInputsTypeNotSupported          = "inputs type not supported for circuit selection"
+	ErrorInputsTooLarge                  = "inputs require larger circuit configuration"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iden3/go-circuits/v2
 
-go 1.18
+go 1.21
 
 require (
 	github.com/iden3/go-iden3-core/v2 v2.3.2

--- a/min_circuit.go
+++ b/min_circuit.go
@@ -1,0 +1,154 @@
+package circuits
+
+import (
+	"github.com/iden3/go-merkletree-sql/v2"
+	"github.com/pkg/errors"
+)
+
+// SelectMinCircuitForInputs inspects the provided circuit inputs and selects
+// the smallest circuit variant that can accommodate them.
+//
+// It analyzes merkle proof depths and query value array sizes to determine
+// the minimum required circuit configuration, returning:
+//   - CircuitID: the specific circuit variant identifier
+//   - BaseConfig: the configuration to use when marshaling inputs
+//   - error: if the input type is unsupported or exceeds all available presets
+//
+// Supported input types:
+//   - AtomicQueryV3Inputs / *AtomicQueryV3Inputs
+//   - AtomicQueryV3OnChainInputs / *AtomicQueryV3OnChainInputs
+//   - AuthV3Inputs / *AuthV3Inputs
+//
+// The returned BaseConfig should be assigned to the input's BaseConfig field
+// before calling InputsMarshal() to ensure correct array padding.
+func SelectMinCircuitForInputs(input any) (CircuitID, BaseConfig, error) {
+	switch v := input.(type) {
+	case AtomicQueryV3Inputs:
+		return minCircuitForAtomicQueryV3(v)
+	case *AtomicQueryV3Inputs:
+		if v == nil {
+			return "", BaseConfig{}, errors.New(ErrorInputsTypeNotSupported)
+		}
+		return minCircuitForAtomicQueryV3(*v)
+	case AtomicQueryV3OnChainInputs:
+		return minCircuitForAtomicQueryV3OnChain(v)
+	case *AtomicQueryV3OnChainInputs:
+		if v == nil {
+			return "", BaseConfig{}, errors.New(ErrorInputsTypeNotSupported)
+		}
+		return minCircuitForAtomicQueryV3OnChain(*v)
+	case AuthV3Inputs:
+		return minCircuitForAuthV3(v)
+	case *AuthV3Inputs:
+		if v == nil {
+			return "", BaseConfig{}, errors.New(ErrorInputsTypeNotSupported)
+		}
+		return minCircuitForAuthV3(*v)
+	default:
+		return "", BaseConfig{}, errors.New(ErrorInputsTypeNotSupported)
+	}
+}
+
+func minCircuitForAtomicQueryV3(a AtomicQueryV3Inputs) (CircuitID, BaseConfig, error) {
+	mtReq, mtClaimReq, valueReq := atomicQueryV3Requirements(a.Claim, a.Query, a.ProofType)
+
+	if fitsAtomicQueryV3Config(mtReq, mtClaimReq, valueReq, presetCfg16_16_64_32) {
+		return CircuitID(string(AtomicQueryV3StableCircuitID) + "-16-16-64"), presetCfg16_16_64_32, nil
+	}
+	if fitsAtomicQueryV3Config(mtReq, mtClaimReq, valueReq, presetCfg40_32_64_64) {
+		return AtomicQueryV3StableCircuitID, presetCfg40_32_64_64, nil
+	}
+	return "", BaseConfig{}, errors.New(ErrorInputsTooLarge)
+}
+
+func minCircuitForAtomicQueryV3OnChain(a AtomicQueryV3OnChainInputs) (CircuitID, BaseConfig, error) {
+	mtReq, mtClaimReq, valueReq := atomicQueryV3Requirements(a.Claim, a.Query, a.ProofType)
+	mtOnChainReq := 0
+
+	if a.IsBJJAuthEnabled == 1 {
+		mtReq = max(mtReq,
+			proofSiblingsLen(a.AuthClaimIncMtp),
+			proofSiblingsLen(a.AuthClaimNonRevMtp),
+		)
+		mtOnChainReq = proofSiblingsLen(a.GISTProof.Proof)
+	}
+
+	if fitsAtomicQueryV3OnChainConfig(mtReq, mtClaimReq, valueReq, mtOnChainReq, presetCfg16_16_64_32) {
+		return CircuitID(string(AtomicQueryV3OnChainStableCircuitID) + "-16-16-64-16-32"), presetCfg16_16_64_32, nil
+	}
+	if fitsAtomicQueryV3OnChainConfig(mtReq, mtClaimReq, valueReq, mtOnChainReq, presetCfg40_32_64_64) {
+		return AtomicQueryV3OnChainStableCircuitID, presetCfg40_32_64_64, nil
+	}
+	return "", BaseConfig{}, errors.New(ErrorInputsTooLarge)
+}
+
+func minCircuitForAuthV3(a AuthV3Inputs) (CircuitID, BaseConfig, error) {
+	mtReq := max(
+		proofSiblingsLen(a.AuthClaimIncMtp),
+		proofSiblingsLen(a.AuthClaimNonRevMtp),
+	)
+	mtOnChainReq := proofSiblingsLen(a.GISTProof.Proof)
+
+	if fitsAuthV3Config(mtReq, mtOnChainReq, presetCfg8_32) {
+		return AuthV3_8_32CircuitID, presetCfg8_32, nil
+	}
+	if fitsAuthV3Config(mtReq, mtOnChainReq, presetCfg40_32_64_64) {
+		return AuthV3CircuitID, presetCfg40_32_64_64, nil
+	}
+	return "", BaseConfig{}, errors.New(ErrorInputsTooLarge)
+}
+
+func atomicQueryV3Requirements(
+	claim ClaimWithSigAndMTPProof,
+	query Query,
+	proofType ProofType,
+) (mtReq, mtClaimReq, valueReq int) {
+	mtReq = proofSiblingsLen(claim.NonRevProof.Proof)
+
+	switch proofType {
+	case BJJSignatureProofType:
+		if claim.SignatureProof != nil {
+			mtReq = max(
+				mtReq,
+				proofSiblingsLen(claim.SignatureProof.IssuerAuthIncProof.Proof),
+				proofSiblingsLen(claim.SignatureProof.IssuerAuthNonRevProof.Proof),
+			)
+		}
+	case Iden3SparseMerkleTreeProofType:
+		if claim.IncProof != nil {
+			mtReq = max(mtReq, proofSiblingsLen(claim.IncProof.Proof))
+		}
+	}
+
+	if query.ValueProof != nil {
+		mtClaimReq = proofSiblingsLen(query.ValueProof.MTP)
+	}
+	valueReq = len(query.Values)
+
+	return mtReq, mtClaimReq, valueReq
+}
+
+func fitsAtomicQueryV3Config(mtReq, mtClaimReq, valueReq int, cfg BaseConfig) bool {
+	return mtReq <= cfg.GetMTLevel() &&
+		mtClaimReq <= cfg.GetMTLevelsClaim() &&
+		valueReq <= cfg.GetValueArrSize()
+}
+
+func fitsAtomicQueryV3OnChainConfig(mtReq, mtClaimReq, valueReq, mtOnChainReq int, cfg BaseConfig) bool {
+	return mtReq <= cfg.GetMTLevel() &&
+		mtClaimReq <= cfg.GetMTLevelsClaim() &&
+		valueReq <= cfg.GetValueArrSize() &&
+		mtOnChainReq <= cfg.GetMTLevelOnChain()
+}
+
+func fitsAuthV3Config(mtReq, mtOnChainReq int, cfg BaseConfig) bool {
+	return mtReq <= cfg.GetMTLevel() &&
+		mtOnChainReq <= cfg.GetMTLevelOnChain()
+}
+
+func proofSiblingsLen(proof *merkletree.Proof) int {
+	if proof == nil {
+		return 0
+	}
+	return len(proof.AllSiblings())
+}

--- a/min_circuit.go
+++ b/min_circuit.go
@@ -5,47 +5,49 @@ import (
 	"github.com/pkg/errors"
 )
 
-// SelectMinCircuitForInputs inspects the provided circuit inputs and selects
-// the smallest circuit variant that can accommodate them.
-//
-// It analyzes merkle proof depths and query value array sizes to determine
-// the minimum required circuit configuration, returning:
-//   - CircuitID: the specific circuit variant identifier
-//   - BaseConfig: the configuration to use when marshaling inputs
-//   - error: if the input type is unsupported or exceeds all available presets
-//
-// Supported input types:
-//   - AtomicQueryV3Inputs / *AtomicQueryV3Inputs
-//   - AtomicQueryV3OnChainInputs / *AtomicQueryV3OnChainInputs
-//   - AuthV3Inputs / *AuthV3Inputs
-//
-// The returned BaseConfig should be assigned to the input's BaseConfig field
-// before calling InputsMarshal() to ensure correct array padding.
-func SelectMinCircuitForInputs(input any) (CircuitID, BaseConfig, error) {
-	switch v := input.(type) {
-	case AtomicQueryV3Inputs:
-		return minCircuitForAtomicQueryV3(v)
+// MinCircuitInput is a type constraint for inputs that support minimal circuit
+// selection.
+type MinCircuitInput interface {
+	*AtomicQueryV3Inputs | *AtomicQueryV3OnChainInputs | *AuthV3Inputs
+}
+
+// AdjustInputsForMinCircuit inspects the provided circuit inputs, selects
+// the smallest circuit variant that can accommodate them, and modifies
+// the input's configuration in place.
+func AdjustInputsForMinCircuit[T MinCircuitInput](input T) (CircuitID, error) {
+	switch v := any(input).(type) {
 	case *AtomicQueryV3Inputs:
 		if v == nil {
-			return "", BaseConfig{}, errors.New(ErrorInputsTypeNotSupported)
+			return "", errors.New(ErrorInputsTypeNotSupported)
 		}
-		return minCircuitForAtomicQueryV3(*v)
-	case AtomicQueryV3OnChainInputs:
-		return minCircuitForAtomicQueryV3OnChain(v)
+		circuitID, cfg, err := minCircuitForAtomicQueryV3(*v)
+		if err != nil {
+			return "", err
+		}
+		v.BaseConfig = cfg
+		return circuitID, nil
 	case *AtomicQueryV3OnChainInputs:
 		if v == nil {
-			return "", BaseConfig{}, errors.New(ErrorInputsTypeNotSupported)
+			return "", errors.New(ErrorInputsTypeNotSupported)
 		}
-		return minCircuitForAtomicQueryV3OnChain(*v)
-	case AuthV3Inputs:
-		return minCircuitForAuthV3(v)
+		circuitID, cfg, err := minCircuitForAtomicQueryV3OnChain(*v)
+		if err != nil {
+			return "", err
+		}
+		v.BaseConfig = cfg
+		return circuitID, nil
 	case *AuthV3Inputs:
 		if v == nil {
-			return "", BaseConfig{}, errors.New(ErrorInputsTypeNotSupported)
+			return "", errors.New(ErrorInputsTypeNotSupported)
 		}
-		return minCircuitForAuthV3(*v)
+		circuitID, cfg, err := minCircuitForAuthV3(*v)
+		if err != nil {
+			return "", err
+		}
+		v.BaseConfig = cfg
+		return circuitID, nil
 	default:
-		return "", BaseConfig{}, errors.New(ErrorInputsTypeNotSupported)
+		return "", errors.New(ErrorInputsTypeNotSupported)
 	}
 }
 

--- a/min_circuit_test.go
+++ b/min_circuit_test.go
@@ -9,162 +9,118 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSelectMinCircuitForInputs_AtomicQueryV3_Sig(t *testing.T) {
+func TestAdjustInputsForMinCircuit_AtomicQueryV3_Sig(t *testing.T) {
 	inputs := createV3Inputs_Sig(t)
 
-	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	circuitID, err := AdjustInputsForMinCircuit(&inputs)
 	require.NoError(t, err)
 	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
-	require.Equal(t, presetCfg16_16_64_32, cfg)
+	require.Equal(t, presetCfg16_16_64_32, inputs.BaseConfig)
 
 	// Verify the config works with InputsMarshal
-	inputs.BaseConfig = cfg
 	_, err = inputs.InputsMarshal()
 	require.NoError(t, err)
 }
 
-func TestSelectMinCircuitForInputs_AtomicQueryV3_Mtp(t *testing.T) {
+func TestAdjustInputsForMinCircuit_AtomicQueryV3_Mtp(t *testing.T) {
 	inputs := createV3Inputs_Mtp(t)
 
-	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	circuitID, err := AdjustInputsForMinCircuit(&inputs)
 	require.NoError(t, err)
 	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
-	require.Equal(t, presetCfg16_16_64_32, cfg)
+	require.Equal(t, presetCfg16_16_64_32, inputs.BaseConfig)
 
 	// Verify the config works with InputsMarshal
-	inputs.BaseConfig = cfg
 	_, err = inputs.InputsMarshal()
 	require.NoError(t, err)
 }
 
-func TestSelectMinCircuitForInputs_AtomicQueryV3_Pointer(t *testing.T) {
-	inputs := createV3Inputs_Sig(t)
-
-	circuitID, cfg, err := SelectMinCircuitForInputs(&inputs)
-	require.NoError(t, err)
-	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
-	require.Equal(t, presetCfg16_16_64_32, cfg)
-}
-
-func TestSelectMinCircuitForInputs_AtomicQueryV3_NilPointer(t *testing.T) {
+func TestAdjustInputsForMinCircuit_AtomicQueryV3_NilPointer(t *testing.T) {
 	var inputs *AtomicQueryV3Inputs
 
-	_, _, err := SelectMinCircuitForInputs(inputs)
+	_, err := AdjustInputsForMinCircuit(inputs)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), ErrorInputsTypeNotSupported)
 }
 
-func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain(t *testing.T) {
+func TestAdjustInputsForMinCircuit_AtomicQueryV3OnChain(t *testing.T) {
 	inputs := createV3OnChainInputs_BJJAuth(t)
 
-	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	circuitID, err := AdjustInputsForMinCircuit(&inputs)
 	require.NoError(t, err)
 	require.Equal(t, CircuitID("credentialAtomicQueryV3OnChain-16-16-64-16-32"), circuitID)
-	require.Equal(t, presetCfg16_16_64_32, cfg)
+	require.Equal(t, presetCfg16_16_64_32, inputs.BaseConfig)
 
 	// Verify the config works with InputsMarshal
-	inputs.BaseConfig = cfg
 	_, err = inputs.InputsMarshal()
 	require.NoError(t, err)
 }
 
-func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain_NoBJJAuth(t *testing.T) {
+func TestAdjustInputsForMinCircuit_AtomicQueryV3OnChain_NoBJJAuth(t *testing.T) {
 	inputs := createV3OnChainInputs_NoBJJAuth(t)
 
-	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	circuitID, err := AdjustInputsForMinCircuit(&inputs)
 	require.NoError(t, err)
 	require.Equal(t, CircuitID("credentialAtomicQueryV3OnChain-16-16-64-16-32"), circuitID)
-	require.Equal(t, presetCfg16_16_64_32, cfg)
+	require.Equal(t, presetCfg16_16_64_32, inputs.BaseConfig)
 
-	inputs.BaseConfig = cfg
 	_, err = inputs.InputsMarshal()
 	require.NoError(t, err)
 }
 
-func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain_Pointer(t *testing.T) {
-	inputs := createV3OnChainInputs_BJJAuth(t)
-
-	circuitID, cfg, err := SelectMinCircuitForInputs(&inputs)
-	require.NoError(t, err)
-	require.Equal(t, CircuitID("credentialAtomicQueryV3OnChain-16-16-64-16-32"), circuitID)
-	require.Equal(t, presetCfg16_16_64_32, cfg)
-}
-
-func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain_NilPointer(t *testing.T) {
+func TestAdjustInputsForMinCircuit_AtomicQueryV3OnChain_NilPointer(t *testing.T) {
 	var inputs *AtomicQueryV3OnChainInputs
 
-	_, _, err := SelectMinCircuitForInputs(inputs)
+	_, err := AdjustInputsForMinCircuit(inputs)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), ErrorInputsTypeNotSupported)
 }
 
-func TestSelectMinCircuitForInputs_AuthV3(t *testing.T) {
+func TestAdjustInputsForMinCircuit_AuthV3(t *testing.T) {
 	inputs := authV3Inputs(t, false)
 
-	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	circuitID, err := AdjustInputsForMinCircuit(&inputs)
 	require.NoError(t, err)
 	require.Equal(t, AuthV3_8_32CircuitID, circuitID)
-	require.Equal(t, presetCfg8_32, cfg)
+	require.Equal(t, presetCfg8_32, inputs.BaseConfig)
 
 	// Verify the config works with InputsMarshal
-	inputs.BaseConfig = cfg
 	_, err = inputs.InputsMarshal()
 	require.NoError(t, err)
 }
 
-func TestSelectMinCircuitForInputs_AuthV3_Pointer(t *testing.T) {
-	inputs := authV3Inputs(t, false)
-
-	circuitID, cfg, err := SelectMinCircuitForInputs(&inputs)
-	require.NoError(t, err)
-	require.Equal(t, AuthV3_8_32CircuitID, circuitID)
-	require.Equal(t, presetCfg8_32, cfg)
-}
-
-func TestSelectMinCircuitForInputs_AuthV3_NilPointer(t *testing.T) {
+func TestAdjustInputsForMinCircuit_AuthV3_NilPointer(t *testing.T) {
 	var inputs *AuthV3Inputs
 
-	_, _, err := SelectMinCircuitForInputs(inputs)
+	_, err := AdjustInputsForMinCircuit(inputs)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), ErrorInputsTypeNotSupported)
 }
 
-func TestSelectMinCircuitForInputs_UnsupportedType(t *testing.T) {
-	_, _, err := SelectMinCircuitForInputs("unsupported")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), ErrorInputsTypeNotSupported)
-
-	_, _, err = SelectMinCircuitForInputs(123)
-	require.Error(t, err)
-
-	_, _, err = SelectMinCircuitForInputs(nil)
-	require.Error(t, err)
-}
-
-func TestSelectMinCircuitForInputs_SelectsSmallestCircuit(t *testing.T) {
+func TestAdjustInputsForMinCircuit_SelectsSmallestCircuit(t *testing.T) {
 	// With small proofs, should select the smaller circuit variant
 	inputs := createV3Inputs_Sig(t)
 
-	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	circuitID, err := AdjustInputsForMinCircuit(&inputs)
 	require.NoError(t, err)
 
 	// The test identity creates shallow trees, so should fit in small circuit
 	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
-	require.Equal(t, 16, cfg.MTLevel)
-	require.Equal(t, 16, cfg.MTLevelClaim)
-	require.Equal(t, 64, cfg.ValueArraySize)
-	require.Equal(t, 32, cfg.MTLevelOnChain)
+	require.Equal(t, 16, inputs.BaseConfig.MTLevel)
+	require.Equal(t, 16, inputs.BaseConfig.MTLevelClaim)
+	require.Equal(t, 64, inputs.BaseConfig.ValueArraySize)
+	require.Equal(t, 32, inputs.BaseConfig.MTLevelOnChain)
 }
 
-func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain_CircuitID(t *testing.T) {
+func TestAdjustInputsForMinCircuit_AtomicQueryV3OnChain_CircuitID(t *testing.T) {
 	inputs := createV3OnChainInputs_BJJAuth(t)
 
-	circuitID, _, err := SelectMinCircuitForInputs(inputs)
+	circuitID, err := AdjustInputsForMinCircuit(&inputs)
 	require.NoError(t, err)
 	require.Equal(t, CircuitID("credentialAtomicQueryV3OnChain-16-16-64-16-32"), circuitID)
 }
 
-func TestSelectMinCircuitForInputs_LargeValueArray(t *testing.T) {
+func TestAdjustInputsForMinCircuit_LargeValueArray(t *testing.T) {
 	inputs := createV3Inputs_Sig(t)
 
 	// Create query with many values (but still within limit)
@@ -173,10 +129,10 @@ func TestSelectMinCircuitForInputs_LargeValueArray(t *testing.T) {
 		inputs.Query.Values[i] = big.NewInt(int64(i))
 	}
 
-	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	circuitID, err := AdjustInputsForMinCircuit(&inputs)
 	require.NoError(t, err)
 	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
-	require.GreaterOrEqual(t, cfg.GetValueArrSize(), 60)
+	require.GreaterOrEqual(t, inputs.BaseConfig.GetValueArrSize(), 60)
 }
 
 // Test fit functions directly to verify selection logic

--- a/min_circuit_test.go
+++ b/min_circuit_test.go
@@ -1,0 +1,362 @@
+package circuits
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	it "github.com/iden3/go-circuits/v2/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectMinCircuitForInputs_AtomicQueryV3_Sig(t *testing.T) {
+	inputs := createV3Inputs_Sig(t)
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	require.NoError(t, err)
+	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
+	require.Equal(t, presetCfg16_16_64_32, cfg)
+
+	// Verify the config works with InputsMarshal
+	inputs.BaseConfig = cfg
+	_, err = inputs.InputsMarshal()
+	require.NoError(t, err)
+}
+
+func TestSelectMinCircuitForInputs_AtomicQueryV3_Mtp(t *testing.T) {
+	inputs := createV3Inputs_Mtp(t)
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	require.NoError(t, err)
+	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
+	require.Equal(t, presetCfg16_16_64_32, cfg)
+
+	// Verify the config works with InputsMarshal
+	inputs.BaseConfig = cfg
+	_, err = inputs.InputsMarshal()
+	require.NoError(t, err)
+}
+
+func TestSelectMinCircuitForInputs_AtomicQueryV3_Pointer(t *testing.T) {
+	inputs := createV3Inputs_Sig(t)
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(&inputs)
+	require.NoError(t, err)
+	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
+	require.Equal(t, presetCfg16_16_64_32, cfg)
+}
+
+func TestSelectMinCircuitForInputs_AtomicQueryV3_NilPointer(t *testing.T) {
+	var inputs *AtomicQueryV3Inputs
+
+	_, _, err := SelectMinCircuitForInputs(inputs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ErrorInputsTypeNotSupported)
+}
+
+func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain(t *testing.T) {
+	inputs := createV3OnChainInputs_BJJAuth(t)
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	require.NoError(t, err)
+	require.Equal(t, CircuitID("credentialAtomicQueryV3OnChain-16-16-64-16-32"), circuitID)
+	require.Equal(t, presetCfg16_16_64_32, cfg)
+
+	// Verify the config works with InputsMarshal
+	inputs.BaseConfig = cfg
+	_, err = inputs.InputsMarshal()
+	require.NoError(t, err)
+}
+
+func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain_NoBJJAuth(t *testing.T) {
+	inputs := createV3OnChainInputs_NoBJJAuth(t)
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	require.NoError(t, err)
+	require.Equal(t, CircuitID("credentialAtomicQueryV3OnChain-16-16-64-16-32"), circuitID)
+	require.Equal(t, presetCfg16_16_64_32, cfg)
+
+	inputs.BaseConfig = cfg
+	_, err = inputs.InputsMarshal()
+	require.NoError(t, err)
+}
+
+func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain_Pointer(t *testing.T) {
+	inputs := createV3OnChainInputs_BJJAuth(t)
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(&inputs)
+	require.NoError(t, err)
+	require.Equal(t, CircuitID("credentialAtomicQueryV3OnChain-16-16-64-16-32"), circuitID)
+	require.Equal(t, presetCfg16_16_64_32, cfg)
+}
+
+func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain_NilPointer(t *testing.T) {
+	var inputs *AtomicQueryV3OnChainInputs
+
+	_, _, err := SelectMinCircuitForInputs(inputs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ErrorInputsTypeNotSupported)
+}
+
+func TestSelectMinCircuitForInputs_AuthV3(t *testing.T) {
+	inputs := authV3Inputs(t, false)
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	require.NoError(t, err)
+	require.Equal(t, AuthV3_8_32CircuitID, circuitID)
+	require.Equal(t, presetCfg8_32, cfg)
+
+	// Verify the config works with InputsMarshal
+	inputs.BaseConfig = cfg
+	_, err = inputs.InputsMarshal()
+	require.NoError(t, err)
+}
+
+func TestSelectMinCircuitForInputs_AuthV3_Pointer(t *testing.T) {
+	inputs := authV3Inputs(t, false)
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(&inputs)
+	require.NoError(t, err)
+	require.Equal(t, AuthV3_8_32CircuitID, circuitID)
+	require.Equal(t, presetCfg8_32, cfg)
+}
+
+func TestSelectMinCircuitForInputs_AuthV3_NilPointer(t *testing.T) {
+	var inputs *AuthV3Inputs
+
+	_, _, err := SelectMinCircuitForInputs(inputs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ErrorInputsTypeNotSupported)
+}
+
+func TestSelectMinCircuitForInputs_UnsupportedType(t *testing.T) {
+	_, _, err := SelectMinCircuitForInputs("unsupported")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ErrorInputsTypeNotSupported)
+
+	_, _, err = SelectMinCircuitForInputs(123)
+	require.Error(t, err)
+
+	_, _, err = SelectMinCircuitForInputs(nil)
+	require.Error(t, err)
+}
+
+func TestSelectMinCircuitForInputs_SelectsSmallestCircuit(t *testing.T) {
+	// With small proofs, should select the smaller circuit variant
+	inputs := createV3Inputs_Sig(t)
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	require.NoError(t, err)
+
+	// The test identity creates shallow trees, so should fit in small circuit
+	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
+	require.Equal(t, 16, cfg.MTLevel)
+	require.Equal(t, 16, cfg.MTLevelClaim)
+	require.Equal(t, 64, cfg.ValueArraySize)
+	require.Equal(t, 32, cfg.MTLevelOnChain)
+}
+
+func TestSelectMinCircuitForInputs_AtomicQueryV3OnChain_CircuitID(t *testing.T) {
+	inputs := createV3OnChainInputs_BJJAuth(t)
+
+	circuitID, _, err := SelectMinCircuitForInputs(inputs)
+	require.NoError(t, err)
+	require.Equal(t, CircuitID("credentialAtomicQueryV3OnChain-16-16-64-16-32"), circuitID)
+}
+
+func TestSelectMinCircuitForInputs_LargeValueArray(t *testing.T) {
+	inputs := createV3Inputs_Sig(t)
+
+	// Create query with many values (but still within limit)
+	inputs.Query.Values = make([]*big.Int, 60)
+	for i := range inputs.Query.Values {
+		inputs.Query.Values[i] = big.NewInt(int64(i))
+	}
+
+	circuitID, cfg, err := SelectMinCircuitForInputs(inputs)
+	require.NoError(t, err)
+	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
+	require.GreaterOrEqual(t, cfg.GetValueArrSize(), 60)
+}
+
+// Test fit functions directly to verify selection logic
+
+func TestFitsAtomicQueryV3Config(t *testing.T) {
+	tests := []struct {
+		name       string
+		mtReq      int
+		mtClaimReq int
+		valueReq   int
+		cfg        BaseConfig
+		want       bool
+	}{
+		{"fits small", 10, 10, 32, presetCfg16_16_64_32, true},
+		{"mt too large for small", 20, 10, 32, presetCfg16_16_64_32, false},
+		{"claim too large for small", 10, 20, 32, presetCfg16_16_64_32, false},
+		{"value too large for small", 10, 10, 100, presetCfg16_16_64_32, false},
+		{"fits large", 30, 30, 60, presetCfg40_32_64_64, true},
+		{"mt too large for large", 50, 10, 32, presetCfg40_32_64_64, false},
+		{"exact boundary small", 16, 16, 64, presetCfg16_16_64_32, true},
+		{"exact boundary large", 40, 32, 64, presetCfg40_32_64_64, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fitsAtomicQueryV3Config(tt.mtReq, tt.mtClaimReq, tt.valueReq, tt.cfg)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFitsAtomicQueryV3OnChainConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		mtReq        int
+		mtClaimReq   int
+		valueReq     int
+		mtOnChainReq int
+		cfg          BaseConfig
+		want         bool
+	}{
+		{"fits small", 10, 10, 32, 20, presetCfg16_16_64_32, true},
+		{"onchain too large for small", 10, 10, 32, 40, presetCfg16_16_64_32, false},
+		{"fits large", 30, 30, 60, 50, presetCfg40_32_64_64, true},
+		{"onchain too large for large", 30, 30, 60, 70, presetCfg40_32_64_64, false},
+		{"exact boundary small", 16, 16, 64, 32, presetCfg16_16_64_32, true},
+		{"exact boundary large", 40, 32, 64, 64, presetCfg40_32_64_64, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fitsAtomicQueryV3OnChainConfig(tt.mtReq, tt.mtClaimReq, tt.valueReq, tt.mtOnChainReq, tt.cfg)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFitsAuthV3Config(t *testing.T) {
+	tests := []struct {
+		name         string
+		mtReq        int
+		mtOnChainReq int
+		cfg          BaseConfig
+		want         bool
+	}{
+		{"fits small", 5, 20, presetCfg8_32, true},
+		{"mt too large for small", 10, 20, presetCfg8_32, false},
+		{"onchain too large for small", 5, 40, presetCfg8_32, false},
+		{"fits large", 30, 50, presetCfg40_32_64_64, true},
+		{"mt too large for large", 50, 50, presetCfg40_32_64_64, false},
+		{"onchain too large for large", 30, 70, presetCfg40_32_64_64, false},
+		{"exact boundary small", 8, 32, presetCfg8_32, true},
+		{"exact boundary large", 40, 64, presetCfg40_32_64_64, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fitsAuthV3Config(tt.mtReq, tt.mtOnChainReq, tt.cfg)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestProofSiblingsLen(t *testing.T) {
+	require.Equal(t, 0, proofSiblingsLen(nil))
+
+	user := it.NewIdentity(t, userPK)
+	proof, _ := user.ClaimMTPRaw(t, user.AuthClaim)
+	require.GreaterOrEqual(t, proofSiblingsLen(proof), 0)
+}
+
+// Helper functions
+
+// createV3OnChainInputs_BJJAuth creates AtomicQueryV3OnChainInputs with BJJ auth enabled.
+func createV3OnChainInputs_BJJAuth(t testing.TB) AtomicQueryV3OnChainInputs {
+	ctx := context.Background()
+	user := it.NewIdentity(t, userPK)
+	issuer := it.NewIdentity(t, issuerPK)
+
+	subjectID := user.ID
+	claim := it.DefaultUserClaim(t, subjectID)
+
+	claimSig := issuer.SignClaim(t, claim)
+	issuerClaimNonRevMtp, _ := issuer.ClaimRevMTPRaw(t, claim)
+	issuerAuthClaimNonRevMtp, _ := issuer.ClaimRevMTPRaw(t, issuer.AuthClaim)
+	issuerAuthClaimMtp, _ := issuer.ClaimMTPRaw(t, issuer.AuthClaim)
+
+	authClaimIncMTP, _ := user.ClaimMTPRaw(t, user.AuthClaim)
+	authClaimNonRevMTP, _ := user.ClaimRevMTPRaw(t, user.AuthClaim)
+
+	challenge := big.NewInt(10)
+	signature, err := user.SignBBJJ(challenge.Bytes())
+	require.NoError(t, err)
+
+	gTree := it.GISTTree(ctx)
+	err = gTree.Add(ctx, user.ID.BigInt(), user.State(t).BigInt())
+	require.NoError(t, err)
+	gistProof, _, err := gTree.GenerateProof(ctx, user.ID.BigInt(), nil)
+	require.NoError(t, err)
+
+	return AtomicQueryV3OnChainInputs{
+		RequestID:                big.NewInt(23),
+		ID:                       &user.ID,
+		ProfileNonce:             big.NewInt(0),
+		ClaimSubjectProfileNonce: big.NewInt(0),
+		Claim: ClaimWithSigAndMTPProof{
+			IssuerID: &issuer.ID,
+			Claim:    claim,
+			NonRevProof: MTProof{
+				TreeState: TreeState{
+					State:          issuer.State(t),
+					ClaimsRoot:     issuer.Clt.Root(),
+					RevocationRoot: issuer.Ret.Root(),
+					RootOfRoots:    issuer.Rot.Root(),
+				},
+				Proof: issuerClaimNonRevMtp,
+			},
+			SignatureProof: &BJJSignatureProof{
+				Signature:       claimSig,
+				IssuerAuthClaim: issuer.AuthClaim,
+				IssuerAuthIncProof: MTProof{
+					TreeState: TreeState{
+						State:          issuer.State(t),
+						ClaimsRoot:     issuer.Clt.Root(),
+						RevocationRoot: issuer.Ret.Root(),
+						RootOfRoots:    issuer.Rot.Root(),
+					},
+					Proof: issuerAuthClaimMtp,
+				},
+				IssuerAuthNonRevProof: MTProof{
+					TreeState: TreeState{
+						State:          issuer.State(t),
+						ClaimsRoot:     issuer.Clt.Root(),
+						RevocationRoot: issuer.Ret.Root(),
+						RootOfRoots:    issuer.Rot.Root(),
+					},
+					Proof: issuerAuthClaimNonRevMtp,
+				},
+			},
+		},
+		AuthClaim:          user.AuthClaim,
+		AuthClaimIncMtp:    authClaimIncMTP,
+		AuthClaimNonRevMtp: authClaimNonRevMTP,
+		TreeState:          GetTreeState(t, user),
+		GISTProof: GISTProof{
+			Root:  gTree.Root(),
+			Proof: gistProof,
+		},
+		Signature:        signature,
+		Challenge:        challenge,
+		Query:            Query{Operator: EQ, Values: []*big.Int{big.NewInt(10)}, SlotIndex: 2},
+		CurrentTimeStamp: timestamp,
+		ProofType:        BJJSignatureProofType,
+		IsBJJAuthEnabled: 1,
+	}
+}
+
+// createV3OnChainInputs_NoBJJAuth creates AtomicQueryV3OnChainInputs without BJJ auth.
+func createV3OnChainInputs_NoBJJAuth(t testing.TB) AtomicQueryV3OnChainInputs {
+	inputs := createV3OnChainInputs_BJJAuth(t)
+	inputs.IsBJJAuthEnabled = 0
+	return inputs
+}

--- a/min_circuit_test.go
+++ b/min_circuit_test.go
@@ -106,10 +106,10 @@ func TestAdjustInputsForMinCircuit_SelectsSmallestCircuit(t *testing.T) {
 
 	// The test identity creates shallow trees, so should fit in small circuit
 	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
-	require.Equal(t, 16, inputs.BaseConfig.MTLevel)
-	require.Equal(t, 16, inputs.BaseConfig.MTLevelClaim)
-	require.Equal(t, 64, inputs.BaseConfig.ValueArraySize)
-	require.Equal(t, 32, inputs.BaseConfig.MTLevelOnChain)
+	require.Equal(t, 16, inputs.MTLevel)
+	require.Equal(t, 16, inputs.MTLevelClaim)
+	require.Equal(t, 64, inputs.ValueArraySize)
+	require.Equal(t, 32, inputs.MTLevelOnChain)
 }
 
 func TestAdjustInputsForMinCircuit_AtomicQueryV3OnChain_CircuitID(t *testing.T) {
@@ -132,7 +132,7 @@ func TestAdjustInputsForMinCircuit_LargeValueArray(t *testing.T) {
 	circuitID, err := AdjustInputsForMinCircuit(&inputs)
 	require.NoError(t, err)
 	require.Equal(t, CircuitID("credentialAtomicQueryV3-16-16-64"), circuitID)
-	require.GreaterOrEqual(t, inputs.BaseConfig.GetValueArrSize(), 60)
+	require.GreaterOrEqual(t, inputs.GetValueArrSize(), 60)
 }
 
 // Test fit functions directly to verify selection logic

--- a/query.go
+++ b/query.go
@@ -126,7 +126,7 @@ func (v *Vector) Compare(t int) (bool, error) {
 		if len(v.y) < 2 {
 			return false, nil
 		}
-		if !(v.x.Cmp(v.y[0]) >= 0 && v.x.Cmp(v.y[1]) <= 0) {
+		if v.x.Cmp(v.y[0]) < 0 || v.x.Cmp(v.y[1]) > 0 {
 			return true, nil
 		}
 		return false, nil

--- a/testing/identity.go
+++ b/testing/identity.go
@@ -46,7 +46,7 @@ func AuthV2ClaimFromPubKey(X, Y *big.Int) (*core.Claim, error) {
 
 func Generate(ctx context.Context, privKHex string) (*core.ID,
 	*merkletree.MerkleTree, *merkletree.MerkleTree, *merkletree.MerkleTree,
-	error, *core.Claim, *babyjub.PrivateKey) {
+	*core.Claim, *babyjub.PrivateKey, error) {
 
 	// extract pubKey
 	var privKey babyjub.PrivateKey
@@ -61,36 +61,36 @@ func Generate(ctx context.Context, privKHex string) (*core.ID,
 	claimsTree, err := merkletree.NewMerkleTree(ctx, memory.NewMemoryStorage(),
 		40)
 	if err != nil {
-		return nil, nil, nil, nil, err, nil, nil
+		return nil, nil, nil, nil, nil, nil, err
 	}
 	// create auth claim
 	authClaim, err := AuthClaimFromPubKey(X, Y)
 	if err != nil {
-		return nil, nil, nil, nil, err, nil, nil
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	// add auth claim to claimsMT
 	hi, hv, err := claimsIndexValueHashes(*authClaim)
 	if err != nil {
-		return nil, nil, nil, nil, err, nil, nil
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	err = claimsTree.Add(ctx, hi, hv)
 	if err != nil {
-		return nil, nil, nil, nil, err, nil, nil
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	state, _ := poseidon.Hash([]*big.Int{claimsTree.Root().BigInt(), big.NewInt(0), big.NewInt(0)})
 	// create new identity
 	identifier, err := core.NewIDFromIdenState(core.TypeDefault, state)
 	if err != nil {
-		return nil, nil, nil, nil, err, nil, nil
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	revTree, _ := merkletree.NewMerkleTree(ctx, memory.NewMemoryStorage(), 40)
 	rootsTree, _ := merkletree.NewMerkleTree(ctx, memory.NewMemoryStorage(), 40)
 
-	return identifier, claimsTree, revTree, rootsTree, nil, authClaim, &privKey
+	return identifier, claimsTree, revTree, rootsTree, authClaim, &privKey, nil
 }
 
 func CalcStateFromRoots(claimsTree *merkletree.MerkleTree,
@@ -120,7 +120,7 @@ func AuthClaimFullInfo(ctx context.Context, privKeyHex string,
 	*merkletree.MerkleTree, *merkletree.MerkleTree, *merkletree.Proof,
 	*merkletree.Proof, *babyjub.Signature, error) {
 
-	identity, claimsTree, revTree, rootsTree, err, claim, privateKey :=
+	identity, claimsTree, revTree, rootsTree, claim, privateKey, err :=
 		Generate(ctx, privKeyHex)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, nil, nil, err


### PR DESCRIPTION
## Summary

- Add `AdjustInputsForMinCircuit` generic helper that inspects input proofs/values, selects the smallest circuit variant, and modifies the input's `BaseConfig` in place
- Fix all golangci-lint errors across the codebase
- Update GitHub Actions for Go 1.21+ support

### AdjustInputsForMinCircuit

Uses generics with pointer type constraint for compile-time type safety:

```go
type MinCircuitInput interface {
    *AtomicQueryV3Inputs | *AtomicQueryV3OnChainInputs | *AuthV3Inputs
}

func AdjustInputsForMinCircuit[T MinCircuitInput](input T) (CircuitID, error)
```

Supported circuit presets:
- 40-32-64-64 (large, default)
- 16-16-64-32 (small)
- 8-32 (AuthV3 small)

### Lint Fixes

- Handle file close error in orderSignals
- Remove redundant embedded field selectors
- Apply De Morgan's law in query logic
- Move error to last return position in `Generate` function

### CI Updates

- Update to actions/checkout@v6, actions/setup-go@v6
- Update golangci-lint-action@v9 with golangci-lint v2.8.0
- Expand test matrix: Go 1.21, 1.22, 1.23, 1.24, 1.25
- Use setup-go built-in caching (removed separate cache action)
- Run linter on Go 1.25